### PR TITLE
Add a waitContainer and a tearDown function

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,7 @@ You can run tests using `make test`. Tests are using `testify` package to create
     * Launch a task
     * Kill the container main PID
     * Task will remain running but the container has been killed by Docker
-* [IMPROVEMENT] Add teardown function to executor
-  * When a post-start hook or a pre-stop hook fail, executor is stopped but the container is not (we must run the "stop procedure" when an error happens, whatever the error could be)
+* [IMPROVEMENT] Allow a hook to don't stop executor when failing (and to continue to executor next hooks)
 * [IMPROVEMENT] Trap SIGKILL in order to gracefuly shutdown the executor
 * [IMPROVEMENT] Change hooks system to plugins system
   * Some hooks work on several "when" (eg. post-run, pre-stop)

--- a/README.md
+++ b/README.md
@@ -139,11 +139,6 @@ You can run tests using `make test`. Tests are using `testify` package to create
 
 ## TODO
 
-* [BUG] Attach to container in order to shutdown the executor on container stops
-  * Reproduce:
-    * Launch a task
-    * Kill the container main PID
-    * Task will remain running but the container has been killed by Docker
 * [IMPROVEMENT] Allow a hook to don't stop executor when failing (and to continue to executor next hooks)
 * [IMPROVEMENT] Trap SIGKILL in order to gracefuly shutdown the executor
 * [IMPROVEMENT] Change hooks system to plugins system

--- a/container/containerizer.go
+++ b/container/containerizer.go
@@ -14,6 +14,7 @@ type Containerizer interface {
 	ContainerRemove(id string) error                                                // Removes the given container
 	ContainerRun(id string) error                                                   // Starts the given container
 	ContainerStop(id string) error                                                  // Stops the given container
+	ContainerWait(id string) (code int, err error)                                  // Wait for the given container to stop, returning its exit code
 	ContainerExec(ctx context.Context, id string, cmd []string) (result chan error) // Executes the given command with the given context in the given container and returns result in a chan (asynchronous)
 	ContainerGetIPs(id string) (ips map[string]net.IP, err error)                   // Returns the IP of the given container
 }

--- a/container/docker.go
+++ b/container/docker.go
@@ -206,3 +206,9 @@ func (c *DockerContainerizer) ContainerExec(ctx context.Context, id string, cmd 
 
 	return result
 }
+
+// ContainerWait waits for the given container to stop and returns its
+// exit code. This function is blocking.
+func (c *DockerContainerizer) ContainerWait(id string) (int, error) {
+	return c.Client.WaitContainer(id)
+}

--- a/types/types.go
+++ b/types/types.go
@@ -68,3 +68,8 @@ func (f *FakeContainerizer) ContainerExec(ctx context.Context, id string, cmd []
 
 	return ch
 }
+
+// ContainerWait returns the 0 exit code with no error
+func (f *FakeContainerizer) ContainerWait(id string) (code int, err error) {
+	return 0, nil
+}


### PR DESCRIPTION
The waitContainer function waits for container to exit (with or without error) and then triggers the tearDown function, in charge of gracefully killing associated task.