### PR TITLE
make healthcheck command check the return code

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,8 @@ func init() {
 	viper.BindPFlag("proc_path", rootCmd.PersistentFlags().Lookup("proc_path"))
 	rootCmd.PersistentFlags().Duration("registering_retry", 100*time.Millisecond, "Executor registering delay in duration")
 	viper.BindPFlag("registering_retry", rootCmd.PersistentFlags().Lookup("registering_retry"))
+	rootCmd.PersistentFlags().Duration("docker_exec_poll_interval", 1*time.Second, "Rate of docker exec polling for result")
+	viper.BindPFlag("docker_exec_poll_interval", rootCmd.PersistentFlags().Lookup("docker_exec_poll_interval"))
 
 	// Iptables hook
 	viper.SetDefault("iptables.ip_forwarding", true)


### PR DESCRIPTION
Current implementation, create a docker Exec, launch it and never check the result of this exec.

The only  case when a healthcheck command fail is when dockerExec creation or launch fail. Not when the command runned fail.